### PR TITLE
fix link to prosys.kaist.ac.kr/recursion

### DIFF
--- a/recursion.html
+++ b/recursion.html
@@ -7,7 +7,7 @@
     <script>
         // Function to perform the redirect
         function redirect() {
-            window.location.href = 'http://recursion.kaist.ac.kr';
+            window.location.href = 'http://prosys.kaist.ac.kr/recursion/';
         }
 
         // Set a timeout to call the redirect function after 5 seconds
@@ -30,6 +30,6 @@
     </script>
 </head>
 <body>
-    <p>visiting <a href="https://recursion.kaist.ac.kr">the recursion world</a> in <span id="countdown">5</span> seconds</p>
+    <p>visiting <a href="https://prosys.kaist.ac.kr/recursion/">the recursion world</a> in <span id="countdown">5</span> seconds</p>
 </body>
 </html>


### PR DESCRIPTION
현재 리다이렉트 링크가 작동하지 않는 `recursion.kaist.ac.kr`로 설정되어 있어, 작동하는 `prosys.kaist.ac.kr/recursion`으로 수정했습니다.