### PR TITLE
fix quine

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
     <div class="content-box">
       <h2>코드</h2>
       <pre><code class="language-ocaml">
-(fun x -> Printf.printf "%s %s" x x) "(fun x -> Printf.printf \"%s %s\" x x)"
+(fun x -> Printf.printf "%s %S" x x) "(fun x -> Printf.printf \"%s %S\" x x)"
         </code></pre>
       <!-- Prism.js JS -->
       <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>


### PR DESCRIPTION
자기 자신을 출력하는 코드를 실행할 시, 뒤쪽 따옴표가 안 보이는 문제가 있어 수정하려 합니다.